### PR TITLE
HTTP 통신 관련 인증 보완

### DIFF
--- a/src/main/java/com/nhnacademy/marketgg/client/aspect/JwtAspect.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/aspect/JwtAspect.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.marketgg.client.aspect;
 
-import static com.nhnacademy.marketgg.client.util.GgUrlUtils.WEEK_SECOND;
+import static com.nhnacademy.marketgg.client.util.GgUtils.WEEK_SECOND;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.nhnacademy.marketgg.client.jwt.JwtInfo;
@@ -81,7 +81,7 @@ public class JwtAspect {
 
         ResponseEntity<Void> response
             = restTemplate.exchange(gatewayOrigin + "/auth/v1/members/token/refresh", HttpMethod.GET, httpEntity,
-            Void.class);
+                                    Void.class);
 
         if (this.isInvalid(response)) {
             return;

--- a/src/main/java/com/nhnacademy/marketgg/client/config/WebSecurityConfig.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/config/WebSecurityConfig.java
@@ -52,7 +52,7 @@ public class WebSecurityConfig {
         http.csrf();
 
         http.addFilterBefore(new AuthenticationFilter(redisTemplate, objectMapper),
-            UsernamePasswordAuthenticationFilter.class);
+                             UsernamePasswordAuthenticationFilter.class);
 
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
@@ -64,7 +64,7 @@ public class WebSecurityConfig {
             .antMatchers("/admin/**").hasRole("ADMIN")
             // TODO: 로그인이 필요한 경로 추가 해야합니다.
             .antMatchers("/cart/**", "/dibs/**", "/members/dibs/**", "/members/ggpass/**",
-                "/customer-services/categories/" + OTO_CODE + "/**").authenticated()
+                         "/customer-services/categories/" + OTO_CODE + "/**", "/orders/**").authenticated()
             .anyRequest().permitAll();
 
         http.headers()

--- a/src/main/java/com/nhnacademy/marketgg/client/dto/ShopResult.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/dto/ShopResult.java
@@ -2,6 +2,7 @@ package com.nhnacademy.marketgg.client.dto;
 
 import com.nhnacademy.marketgg.client.dto.response.common.ErrorEntity;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -18,14 +19,14 @@ import lombok.RequiredArgsConstructor;
  * @version 1.0
  * @since 1.0
  */
-@RequiredArgsConstructor
+@NoArgsConstructor
 @Getter
 public class ShopResult<T> {
 
-    private final boolean success;
+    private boolean success;
 
-    private final T data;
+    private T data;
 
-    private final ErrorEntity error;
+    private ErrorEntity error;
 
 }

--- a/src/main/java/com/nhnacademy/marketgg/client/dto/ShopResult.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/dto/ShopResult.java
@@ -3,7 +3,6 @@ package com.nhnacademy.marketgg.client.dto;
 import com.nhnacademy.marketgg.client.dto.response.common.ErrorEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 /**
  * Market GG 에서 공통 응답 객체입니다.

--- a/src/main/java/com/nhnacademy/marketgg/client/filter/AuthenticationFilter.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/filter/AuthenticationFilter.java
@@ -4,10 +4,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nhnacademy.marketgg.client.jwt.JwtInfo;
-import com.nhnacademy.marketgg.client.jwt.Payload;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Objects;
 import java.util.Optional;
 import javax.servlet.FilterChain;
@@ -24,6 +21,14 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+/**
+ * 인증 Principal 에 세션 아이디 및 자격 증명(Credential) 등 JWT 저장 관련 작업을 수행합니다.
+ * {@link OncePerRequestFilter} 추상 클래스를 상속받아 사용자의 요청 당 한 번만 필터가 동작합니다.
+ *
+ * @author 윤동열
+ * @version 1.0.0
+ * @since 1.0.0
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class AuthenticationFilter extends OncePerRequestFilter {
@@ -57,10 +62,10 @@ public class AuthenticationFilter extends OncePerRequestFilter {
             // Authentication Principal 에 SessionId, Credential 에 JWT 저장
             Authentication authentication =
                 new UsernamePasswordAuthenticationToken(sessionId, jwtInfo.getJwt(),
-                    jwtInfo.getAuthorities()
-                           .stream()
-                           .map(SimpleGrantedAuthority::new)
-                           .collect(toList()));
+                                                        jwtInfo.getAuthorities()
+                                                               .stream()
+                                                               .map(SimpleGrantedAuthority::new)
+                                                               .collect(toList()));
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
             filterChain.doFilter(request, response);

--- a/src/main/java/com/nhnacademy/marketgg/client/util/GgUtils.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/util/GgUtils.java
@@ -6,21 +6,19 @@ import lombok.NoArgsConstructor;
 /**
  * 마이크로서비스에 API 요청을 보낼 때 필요한 URL 정보를 제공하는 인터페이스입니다.
  *
+ * @author 윤동열
  * @author 이제훈
  * @version 1.0
  * @since 1.0
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class GgUrlUtils {
+public final class GgUtils {
 
     public static final int WEEK_SECOND = 60 * 60 * 24 * 7;
-
-    public static final String GATEWAY_HOST_URL = "http://127.0.0.1:6060";
 
     public static final String SHOP_SERVICE_PREFIX_V1 = "/shop/v1";
     public static final String AUTH_SERVICE_PREFIX_V1 = "/auth/v1";
 
-    public static final String ORDERS_PATH_PREFIX = "/orders";
     public static final String REDIRECT_TO_INDEX = "redirect:/";
 
 }

--- a/src/main/java/com/nhnacademy/marketgg/client/util/JwtUtils.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/util/JwtUtils.java
@@ -1,0 +1,27 @@
+package com.nhnacademy.marketgg.client.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * JWT 관련 유틸리티 클래스입니다.
+ *
+ * @author 이제훈
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class JwtUtils {
+
+    /**
+     * 현재 세션 유지가 되고 있는 회원 정보의 JWT 정보를 반환합니다.
+     * WebClient 등 HTTP 통신을 위한 인터페이스에서 토큰 기반 인증(Bearer Authentication) 등에 해당 메서드를 활용됩니다.
+     *
+     * @return 로그인 한 회원의 JWT
+     */
+    public static String getToken() {
+        return (String) SecurityContextHolder.getContext().getAuthentication().getCredentials();
+    }
+
+}

--- a/src/main/java/com/nhnacademy/marketgg/client/web/AuthController.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/web/AuthController.java
@@ -1,7 +1,7 @@
 package com.nhnacademy.marketgg.client.web;
 
-import static com.nhnacademy.marketgg.client.util.GgUrlUtils.REDIRECT_TO_INDEX;
-import static com.nhnacademy.marketgg.client.util.GgUrlUtils.WEEK_SECOND;
+import static com.nhnacademy.marketgg.client.util.GgUtils.REDIRECT_TO_INDEX;
+import static com.nhnacademy.marketgg.client.util.GgUtils.WEEK_SECOND;
 
 import com.nhnacademy.marketgg.client.annotation.NoAuth;
 import com.nhnacademy.marketgg.client.dto.request.LoginRequest;

--- a/src/main/java/com/nhnacademy/marketgg/client/web/Oauth2Controller.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/web/Oauth2Controller.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.marketgg.client.web;
 
-import static com.nhnacademy.marketgg.client.util.GgUrlUtils.WEEK_SECOND;
+import static com.nhnacademy.marketgg.client.util.GgUtils.WEEK_SECOND;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nhnacademy.marketgg.client.jwt.JwtInfo;


### PR DESCRIPTION
## 개요

- Closes #168
- HTTP 통신 인터페이스로 `WebClient` 사용 시 `JwtAddInterceptor` 를 타지 않는 이슈로 인해 HTTP 통신 관련 인증 보완

## To-do

- [x] 인증 필터 문서화
- [x] JWT 유틸리티 클래스 추가
- [x] 코드 포매팅
- [x] 유틸리티 클래스명 및 import 수정 (from `GgUrlUtils` to `GgUtils`)
- [x] 공통 응답 객체 역직렬화 되도록 수정
