### PR TITLE
주문 프로세스 UI 테스트

### DIFF
--- a/src/main/java/com/nhnacademy/marketgg/client/dto/order/OrderCreateRequest.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/dto/order/OrderCreateRequest.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.marketgg.client.dto.order;
 
+import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -17,11 +18,25 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public class OrderCreateRequest {
 
+    @NotBlank
+    @Size(max = 100)
+    private final String name;
+
+    @NotBlank
+    @Size(max = 100)
+    private final String email;
+
     @NotNull
-    private final Long totalAmount;
+    private final Long deliveryAddressId;
+
+    @NotNull
+    private final List<Long> productIds;
 
     @NotNull
     private final Integer usedPoint;
+
+    @NotNull
+    private final Long totalAmount;
 
     private Integer trackingNo;
 
@@ -29,16 +44,6 @@ public class OrderCreateRequest {
     @Size(min = 2, max = 4)
     private final String paymentType;
 
-    @NotBlank
-    @Size(max = 100)
-    private final String orderName;
-
-    // @NotBlank
-    @Size(max = 100)
-    private final String customerName;
-
-    // @NotBlank
-    @Size(max = 100)
-    private final String customerEmail;
+    private Integer expectedSavePoint;
 
 }

--- a/src/main/java/com/nhnacademy/marketgg/client/dto/order/OrderFormResponse.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/dto/order/OrderFormResponse.java
@@ -1,0 +1,55 @@
+package com.nhnacademy.marketgg.client.dto.order;
+
+import com.nhnacademy.marketgg.client.dto.response.DeliveryAddressResponse;
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 주문서 입력 폼 출력을 위해 취합한 정보를 전달하기 위한 DTO 입니다.
+ *
+ * @author 김정민
+ * @author 이제훈
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+@NoArgsConstructor
+@Getter
+public class OrderFormResponse {
+
+    @NotNull
+    private List<ProductToOrder> products;
+
+    @NotNull
+    private Long memberId;
+
+    @NotBlank
+    @Size(max = 100)
+    private String memberName;
+
+    @NotBlank
+    @Size(max = 20)
+    private String memberEmail;
+
+    @NotBlank
+    private String memberGrade;
+
+    @NotNull
+    private List<OrderGivenCoupon> givenCouponList;
+
+    @NotNull
+    private Integer totalPoint;
+
+    @NotNull
+    private List<DeliveryAddressResponse> deliveryAddressList;
+
+    @NotNull
+    private List<String> paymentType;
+
+    @NotNull
+    private Long totalOrigin;
+
+}

--- a/src/main/java/com/nhnacademy/marketgg/client/dto/order/OrderGivenCoupon.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/dto/order/OrderGivenCoupon.java
@@ -1,0 +1,41 @@
+package com.nhnacademy.marketgg.client.dto.order;
+
+import java.time.LocalDateTime;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 주문서 작성 시 회원이 보유한 쿠폰 정보를 전달하기 위한 DTO 입니다.
+ *
+ * @author 김정민
+ * @author 이제훈
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+@NoArgsConstructor
+@Getter
+public class OrderGivenCoupon {
+
+    @NotNull
+    private Long id;
+
+    @NotBlank
+    @Size(max = 20)
+    private String name;
+
+    @NotNull
+    private LocalDateTime createdAt;
+
+    @NotNull
+    private Integer expiredDate;
+
+    @NotNull
+    private Integer minimumMoney;
+
+    @NotNull
+    private Double discountAmount;
+
+}

--- a/src/main/java/com/nhnacademy/marketgg/client/dto/order/OrderToPayment.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/dto/order/OrderToPayment.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.marketgg.client.dto.order;
 
+import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -17,7 +18,7 @@ import org.springframework.lang.Nullable;
  */
 @NoArgsConstructor
 @Getter
-public class OrderToPayment {
+public class OrderToPayment implements Serializable {
 
     @NotBlank
     @Size(min = 6, max = 64)

--- a/src/main/java/com/nhnacademy/marketgg/client/dto/request/CartOrderRequest.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/dto/request/CartOrderRequest.java
@@ -1,11 +1,24 @@
 package com.nhnacademy.marketgg.client.dto.request;
 
 import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 장바구니에 담은 상품 아이디 목록이 담긴 요청 객체입니다.
+ *
+ * @author 김정민
+ * @author 윤동열
+ * @author 이제훈
+ * @version 1.0.0
+ * @since 1.0.0
+ */
 @RequiredArgsConstructor
+@Getter
 public class CartOrderRequest {
 
+    @NotNull
     private final List<Long> id;
 
 }

--- a/src/main/java/com/nhnacademy/marketgg/client/dto/response/DeliveryAddressResponse.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/dto/response/DeliveryAddressResponse.java
@@ -1,22 +1,37 @@
 package com.nhnacademy.marketgg.client.dto.response;
 
-import lombok.AllArgsConstructor;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
- * 배송지 정보를 담은 dto 객체 입니다.
+ * 배송지 정보를 담은 응답 객체입니다.
  *
  * @author 김훈민
+ * @author 이제훈
  * @since 1.0.0
  */
-@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class DeliveryAddressResponse {
 
-    private final Long id;
-    private final Boolean isDefaultAddress;
-    private final Integer zipcode;
-    private final String address;
-    private final String detailAddress;
+    @NotNull
+    private Long id;
+
+    @NotNull
+    private Boolean isDefaultAddress;
+
+    @NotNull
+    private Integer zipcode;
+
+    @NotBlank
+    @Size(max = 100)
+    private String address;
+
+    @NotBlank
+    @Size(max = 100)
+    private String detailAddress;
 
 }

--- a/src/main/java/com/nhnacademy/marketgg/client/repository/order/OrderAdapter.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/repository/order/OrderAdapter.java
@@ -8,9 +8,10 @@ import com.nhnacademy.marketgg.client.dto.PageResult;
 import com.nhnacademy.marketgg.client.dto.ShopResult;
 import com.nhnacademy.marketgg.client.dto.order.OrderCreateRequest;
 import com.nhnacademy.marketgg.client.dto.order.OrderDetailRetrieveResponse;
+import com.nhnacademy.marketgg.client.dto.order.OrderFormResponse;
 import com.nhnacademy.marketgg.client.dto.order.OrderRetrieveResponse;
 import com.nhnacademy.marketgg.client.dto.order.OrderToPayment;
-import com.nhnacademy.marketgg.client.dto.order.ProductToOrder;
+import com.nhnacademy.marketgg.client.dto.request.CartOrderRequest;
 import com.nhnacademy.marketgg.client.dto.response.DeliveryLocationResponseDto;
 import com.nhnacademy.marketgg.client.util.JwtUtils;
 import java.net.URI;
@@ -74,22 +75,22 @@ public class OrderAdapter implements OrderRepository {
     @Override
     public PageResult<OrderRetrieveResponse> retrieveOrders(final Integer page) {
         ResponseEntity<ShopResult<PageResult<OrderRetrieveResponse>>> response
-                = WebClient.builder()
-                           .baseUrl(gatewayIp)
-                           .defaultHeaders(httpHeaders -> {
-                               httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-                               httpHeaders.setAccept(singletonList(MediaType.APPLICATION_JSON));
-                               httpHeaders.setBearerAuth(JwtUtils.getToken());
+            = WebClient.builder()
+                       .baseUrl(gatewayIp)
+                       .defaultHeaders(httpHeaders -> {
+                           httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+                           httpHeaders.setAccept(singletonList(MediaType.APPLICATION_JSON));
+                           httpHeaders.setBearerAuth(JwtUtils.getToken());
+                       })
+                       .build()
+                       .get()
+                       .uri(SHOP_SERVICE_PREFIX_V1 + ORDERS_PATH_PREFIX + "?page=" + page)
+                       .retrieve()
+                       .toEntity(
+                           new ParameterizedTypeReference<ShopResult<PageResult<OrderRetrieveResponse>>>() {
                            })
-                           .build()
-                           .get()
-                           .uri(SHOP_SERVICE_PREFIX_V1 + ORDERS_PATH_PREFIX + "?page=" + page)
-                           .retrieve()
-                           .toEntity(
-                                   new ParameterizedTypeReference<ShopResult<PageResult<OrderRetrieveResponse>>>() {
-                                   })
-                           .blockOptional()
-                           .orElseThrow(NullPointerException::new);
+                       .blockOptional()
+                       .orElseThrow(NullPointerException::new);
 
         return Objects.requireNonNull(response.getBody()).getData();
     }
@@ -103,22 +104,22 @@ public class OrderAdapter implements OrderRepository {
     @Override
     public OrderDetailRetrieveResponse retrieveOrder(final Long orderId) {
         ResponseEntity<ShopResult<OrderDetailRetrieveResponse>> response
-                = WebClient.builder()
-                           .baseUrl(gatewayIp)
-                           .defaultHeaders(httpHeaders -> {
-                               httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-                               httpHeaders.setAccept(singletonList(MediaType.APPLICATION_JSON));
-                               httpHeaders.setBearerAuth(JwtUtils.getToken());
+            = WebClient.builder()
+                       .baseUrl(gatewayIp)
+                       .defaultHeaders(httpHeaders -> {
+                           httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+                           httpHeaders.setAccept(singletonList(MediaType.APPLICATION_JSON));
+                           httpHeaders.setBearerAuth(JwtUtils.getToken());
+                       })
+                       .build()
+                       .get()
+                       .uri(SHOP_SERVICE_PREFIX_V1 + ORDERS_PATH_PREFIX + "/" + orderId)
+                       .retrieve()
+                       .toEntity(
+                           new ParameterizedTypeReference<ShopResult<OrderDetailRetrieveResponse>>() {
                            })
-                           .build()
-                           .get()
-                           .uri(SHOP_SERVICE_PREFIX_V1 + ORDERS_PATH_PREFIX + "/" + orderId)
-                           .retrieve()
-                           .toEntity(
-                                   new ParameterizedTypeReference<ShopResult<OrderDetailRetrieveResponse>>() {
-                                   })
-                           .blockOptional()
-                           .orElseThrow(NullPointerException::new);
+                       .blockOptional()
+                       .orElseThrow(NullPointerException::new);
 
         URI location = response.getHeaders().getLocation();
         return Objects.requireNonNull(response.getBody()).getData();
@@ -150,7 +151,6 @@ public class OrderAdapter implements OrderRepository {
      */
     @Override
     public void createTrackingNo(final Long orderId) {
-
         WebClient client = WebClient.builder()
                                     .baseUrl(gatewayIp)
                                     .defaultHeaders(httpHeaders -> {
@@ -185,7 +185,32 @@ public class OrderAdapter implements OrderRepository {
                      .retrieve()
                      .bodyToMono(new ParameterizedTypeReference<List<DeliveryLocationResponseDto>>() {
                      })
-                     .blockOptional().orElseThrow();
+                     .blockOptional()
+                     .orElseThrow(NullPointerException::new);
+    }
+
+    @Override
+    public OrderFormResponse retrieveOrderForm(CartOrderRequest cartRequest) {
+        ResponseEntity<ShopResult<OrderFormResponse>> response
+            = WebClient.builder()
+                       .baseUrl(gatewayIp)
+                       .defaultHeaders(httpHeaders -> {
+                           httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+                           httpHeaders.setAccept(singletonList(MediaType.APPLICATION_JSON));
+                           httpHeaders.setBearerAuth(JwtUtils.getToken());
+                       })
+                       .build()
+                       .post()
+                       .uri(SHOP_SERVICE_PREFIX_V1 + ORDERS_PATH_PREFIX + "/order-form")
+                       .bodyValue(cartRequest)
+                       .retrieve()
+                       .toEntity(
+                           new ParameterizedTypeReference<ShopResult<OrderFormResponse>>() {
+                           })
+                       .blockOptional()
+                       .orElseThrow(NullPointerException::new);
+
+        return Objects.requireNonNull(response.getBody()).getData();
     }
 
 }

--- a/src/main/java/com/nhnacademy/marketgg/client/repository/order/OrderRepository.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/repository/order/OrderRepository.java
@@ -4,8 +4,10 @@ import com.nhnacademy.marketgg.client.dto.MemberInfo;
 import com.nhnacademy.marketgg.client.dto.PageResult;
 import com.nhnacademy.marketgg.client.dto.order.OrderCreateRequest;
 import com.nhnacademy.marketgg.client.dto.order.OrderDetailRetrieveResponse;
+import com.nhnacademy.marketgg.client.dto.order.OrderFormResponse;
 import com.nhnacademy.marketgg.client.dto.order.OrderRetrieveResponse;
 import com.nhnacademy.marketgg.client.dto.order.OrderToPayment;
+import com.nhnacademy.marketgg.client.dto.request.CartOrderRequest;
 import com.nhnacademy.marketgg.client.dto.response.DeliveryLocationResponseDto;
 import java.util.List;
 
@@ -21,8 +23,8 @@ public interface OrderRepository {
     /**
      * 주문을 생성합니다.
      *
-     * @param orderRequest - 주문 생성 시 필요한 요청 정보 객체
-     * @return
+     * @param orderRequest 주문 생성 시 필요한 요청 정보 객체
+     * @return 결제에 필요한 정보가 담겨있는 {@link OrderToPayment} 객체
      */
     OrderToPayment createOrder(final OrderCreateRequest orderRequest, MemberInfo memberInfo);
 
@@ -36,7 +38,7 @@ public interface OrderRepository {
     /**
      * 주문 상세 정보를 조회합니다.
      *
-     * @param orderId - 주문 번호
+     * @param orderId 주문 번호
      * @return 특정한 주문에 대한 상세 정보 응답 객체
      */
     OrderDetailRetrieveResponse retrieveOrder(final Long orderId);
@@ -44,22 +46,31 @@ public interface OrderRepository {
     /**
      * 주문을 취소한 상태로 처리합니다.
      *
-     * @param orderId - 주문 번호
+     * @param orderId 주문 번호
      */
     void cancelOrder(final Long orderId);
 
     /**
      * 관리자가 운송장 번호를 만듭니다.
      *
-     * @param orderId - 주문 번호
+     * @param orderId 주문 번호
      */
     void createTrackingNo(final Long orderId);
 
     /**
      * 회원이 주문 내역에 있는 운송장 번호로 배송정보를 조회합니다.
      *
-     * @param trackingNo - 운송장 번호
+     * @param trackingNo 운송장 번호
      * @return 배송정보 리스트
      */
     List<DeliveryLocationResponseDto> retrieveDeliveryInfo(final String trackingNo);
+
+    /**
+     * 주문서 작성에 필요한 정보를 조회하는 API 를 요청합니다.
+     *
+     * @param cartResponse 장바구니에 담긴 상품 목록
+     * @return 주문서를 구성하는 주문 상품 정보
+     */
+    OrderFormResponse retrieveOrderForm(final CartOrderRequest cartResponse);
+
 }

--- a/src/main/java/com/nhnacademy/marketgg/client/service/order/GgOrderService.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/service/order/GgOrderService.java
@@ -4,7 +4,10 @@ import com.nhnacademy.marketgg.client.dto.MemberInfo;
 import com.nhnacademy.marketgg.client.dto.PageResult;
 import com.nhnacademy.marketgg.client.dto.order.OrderCreateRequest;
 import com.nhnacademy.marketgg.client.dto.order.OrderDetailRetrieveResponse;
+import com.nhnacademy.marketgg.client.dto.order.OrderFormResponse;
 import com.nhnacademy.marketgg.client.dto.order.OrderRetrieveResponse;
+import com.nhnacademy.marketgg.client.dto.order.OrderToPayment;
+import com.nhnacademy.marketgg.client.dto.request.CartOrderRequest;
 import com.nhnacademy.marketgg.client.dto.response.DeliveryLocationResponseDto;
 import com.nhnacademy.marketgg.client.repository.order.OrderRepository;
 import java.util.List;
@@ -27,11 +30,11 @@ public class GgOrderService implements OrderService {
     /**
      * {@inheritDoc}
      *
-     * @param orderRequest - 주문 생성 시 필요한 요청 정보 객체
+     * @param orderRequest 주문 생성 시 필요한 요청 정보 객체
      */
     @Override
-    public void createOrder(final OrderCreateRequest orderRequest, final MemberInfo memberInfo) {
-        orderRepository.createOrder(orderRequest, memberInfo);
+    public OrderToPayment createOrder(final OrderCreateRequest orderRequest, final MemberInfo memberInfo) {
+        return orderRepository.createOrder(orderRequest, memberInfo);
     }
 
     /**
@@ -47,7 +50,7 @@ public class GgOrderService implements OrderService {
     /**
      * {@inheritDoc}
      *
-     * @param orderId - 주문 번호
+     * @param orderId 주문 번호
      * @return 주문 상세 정보 응답 객체
      */
     @Override
@@ -55,6 +58,11 @@ public class GgOrderService implements OrderService {
         return orderRepository.retrieveOrder(orderId);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param orderId 주문 번호
+     */
     @Override
     public void cancelOrder(final Long orderId) {
         orderRepository.cancelOrder(orderId);
@@ -63,7 +71,7 @@ public class GgOrderService implements OrderService {
     /**
      * 관리자가 운송장 번호 만들기를 요청합니다.
      *
-     * @param orderNo - 주문 번호
+     * @param orderNo 주문 번호
      */
     @Override
     public void createTrackingNo(final Long orderNo) {
@@ -73,12 +81,23 @@ public class GgOrderService implements OrderService {
     /**
      * 회원이 주문 내역에 있는 운송장 번호로 배송정보를 조회합니다.
      *
-     * @param trackingNo - 운송장 번호
+     * @param trackingNo 운송장 번호
      * @return 배송정보 리스트
      */
     @Override
     public List<DeliveryLocationResponseDto> retrieveDeliveryInfo(final String trackingNo) {
         return orderRepository.retrieveDeliveryInfo(trackingNo);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param cartRequest 장바구니에 담긴 상품 목록
+     * @return
+     */
+    @Override
+    public OrderFormResponse retrieveOrderForm(final CartOrderRequest cartRequest) {
+        return orderRepository.retrieveOrderForm(cartRequest);
     }
 
 }

--- a/src/main/java/com/nhnacademy/marketgg/client/service/order/OrderService.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/service/order/OrderService.java
@@ -4,7 +4,10 @@ import com.nhnacademy.marketgg.client.dto.MemberInfo;
 import com.nhnacademy.marketgg.client.dto.PageResult;
 import com.nhnacademy.marketgg.client.dto.order.OrderCreateRequest;
 import com.nhnacademy.marketgg.client.dto.order.OrderDetailRetrieveResponse;
+import com.nhnacademy.marketgg.client.dto.order.OrderFormResponse;
 import com.nhnacademy.marketgg.client.dto.order.OrderRetrieveResponse;
+import com.nhnacademy.marketgg.client.dto.order.OrderToPayment;
+import com.nhnacademy.marketgg.client.dto.request.CartOrderRequest;
 import com.nhnacademy.marketgg.client.dto.response.DeliveryLocationResponseDto;
 import java.util.List;
 
@@ -20,9 +23,9 @@ public interface OrderService {
     /**
      * 주문을 생성합니다.
      *
-     * @param orderRequest - 주문 생성 시 필요한 요청 정보 객체
+     * @param orderRequest 주문 생성 시 필요한 요청 정보 객체
      */
-    void createOrder(final OrderCreateRequest orderRequest, final MemberInfo memberInfo);
+    OrderToPayment createOrder(final OrderCreateRequest orderRequest, final MemberInfo memberInfo);
 
     /**
      * 주문 목록을 조회합니다.
@@ -34,7 +37,7 @@ public interface OrderService {
     /**
      * 주문 상세 조회를 처리합니다.
      *
-     * @param orderId - 주문 번호
+     * @param orderId 주문 번호
      * @return 주문 상세 정보 응답 객체
      */
     OrderDetailRetrieveResponse retrieveOrder(final Long orderId);
@@ -42,11 +45,31 @@ public interface OrderService {
     /**
      * 주문 취소를 처리합니다.
      *
-     * @param orderId - 주문 번호
+     * @param orderId 주문 번호
      */
     void cancelOrder(final Long orderId);
 
+    /**
+     * 운송장 번호 생성을 요청합니다.
+     *
+     * @param orderNo 주문 번호
+     */
     void createTrackingNo(final Long orderNo);
 
+    /**
+     * 배송 정보 내역 조회를 요청합니다.
+     *
+     * @param trackingNo 운송장 번호
+     * @return 운송장 번호에 해당하는 배송 정보 목록
+     */
     List<DeliveryLocationResponseDto> retrieveDeliveryInfo(final String trackingNo);
+
+    /**
+     * 주문하기 전 주문서 작성에 필요한 정보를 조회하는 요청을 수행합니다.
+     *
+     * @param cartRequest 장바구니에 담긴 상품 목록
+     * @return 주문서를 구성하는 주문 상품 정보
+     */
+    OrderFormResponse retrieveOrderForm(final CartOrderRequest cartRequest);
+
 }

--- a/src/main/java/com/nhnacademy/marketgg/client/web/cart/CartController.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/web/cart/CartController.java
@@ -48,14 +48,15 @@ public class CartController {
     // 비동기로 처리 예정
     @PostMapping
     // @ResponseBody
-    public ModelAndView addToProduct(
-        @ModelAttribute @Valid ProductToCartRequest productAddRequest, RedirectAttributes redirectAttributes)
+    public ModelAndView addToProduct(@ModelAttribute @Valid ProductToCartRequest productAddRequest,
+                                     RedirectAttributes redirectAttributes)
         throws UnAuthenticException, UnAuthorizationException, JsonProcessingException {
 
         cartService.addProduct(productAddRequest);
 
         ModelAndView mav = new ModelAndView("/products/" + productAddRequest.getId());
         redirectAttributes.addFlashAttribute("addSuccess", true);
+
         return mav;
     }
 
@@ -92,8 +93,8 @@ public class CartController {
      */
     @PatchMapping
     @ResponseBody
-    public ResponseEntity<CommonResult<String>> updateAmount(
-        @RequestBody @Valid ProductToCartRequest productUpdateRequest)
+    public ResponseEntity<CommonResult<String>> updateAmount(@RequestBody @Valid
+                                                             ProductToCartRequest productUpdateRequest)
         throws UnAuthenticException, UnAuthorizationException, JsonProcessingException {
 
         cartService.updateAmount(productUpdateRequest);

--- a/src/main/java/com/nhnacademy/marketgg/client/web/cart/CartController.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/web/cart/CartController.java
@@ -1,6 +1,5 @@
 package com.nhnacademy.marketgg.client.web.cart;
 
-import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -12,7 +11,6 @@ import com.nhnacademy.marketgg.client.exception.auth.UnAuthenticException;
 import com.nhnacademy.marketgg.client.exception.auth.UnAuthorizationException;
 import com.nhnacademy.marketgg.client.service.CartService;
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -75,28 +73,6 @@ public class CartController {
 
         ModelAndView mav = new ModelAndView("pages/carts/index");
         List<CartProductResponse> carts = cartService.retrieveCarts();
-        // List<CartProductResponse> carts = List.of(
-        //     new CartProductResponse(1L, "포카칩", "https://console.toast.com/project/5WrZ1g5H/storage/object-storage", 10,
-        //         1300L),
-        //     new CartProductResponse(2L, "자몽 주스", "https://console.toast.com/project/5WrZ1g5H/storage/object-storage", 9,
-        //         2000L),
-        //     new CartProductResponse(3L, "오렌지 주스", "https://console.toast.com/project/5WrZ1g5H/storage/object-storage",
-        //         8, 1500L),
-        //     new CartProductResponse(4L, "수미칩", "https://console.toast.com/project/5WrZ1g5H/storage/object-storage", 7,
-        //         1300L),
-        //     new CartProductResponse(5L, "김자몽", "https://console.toast.com/project/5WrZ1g5H/storage/object-storage", 6,
-        //         2300L),
-        //     new CartProductResponse(6L, "델몬트 오렌지", "https://console.toast.com/project/5WrZ1g5H/storage/object-storage",
-        //         5, 2100L),
-        //     new CartProductResponse(7L, "프링글스", "https://console.toast.com/project/5WrZ1g5H/storage/object-storage", 4,
-        //         1000L),
-        //     new CartProductResponse(8L, "자몽 주스", "https://console.toast.com/project/5WrZ1g5H/storage/object-storage", 3,
-        //         1900L),
-        //     new CartProductResponse(9L, "썬키스트 오렌지", "https://console.toast.com/project/5WrZ1g5H/storage/object-storage",
-        //         2, 1200L),
-        //     new CartProductResponse(10L, "포테토칩", "https://console.toast.com/project/5WrZ1g5H/storage/object-storage", 1,
-        //         1500L)
-        // );
         mav.addObject("carts", carts);
 
         if (!memberInfo.isNull()) {

--- a/src/main/java/com/nhnacademy/marketgg/client/web/order/OrderController.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/web/order/OrderController.java
@@ -2,6 +2,7 @@ package com.nhnacademy.marketgg.client.web.order;
 
 import com.nhnacademy.marketgg.client.dto.MemberInfo;
 import com.nhnacademy.marketgg.client.dto.order.OrderCreateRequest;
+import com.nhnacademy.marketgg.client.dto.order.OrderToPayment;
 import com.nhnacademy.marketgg.client.service.order.OrderService;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**
  * 주문에 대한 요청과 응답을 처리하는 클래스입니다.
@@ -35,9 +37,10 @@ public class OrderController {
      */
     @PostMapping("/orders")
     public ModelAndView createOrder(@ModelAttribute @Valid final OrderCreateRequest orderRequest,
-                                    MemberInfo memberInfo) {
+                                    MemberInfo memberInfo, RedirectAttributes attributes) {
 
-        orderService.createOrder(orderRequest, memberInfo);
+        OrderToPayment orderToPayment = orderService.createOrder(orderRequest, memberInfo);
+        attributes.addFlashAttribute("orderToPayment", orderToPayment);
 
         return new ModelAndView("redirect:/payments/request-payment");
     }
@@ -65,6 +68,7 @@ public class OrderController {
     public ModelAndView retrieveDeliveryInfo(@RequestParam @Min(1) final String trackingNo) {
         ModelAndView modelAndView = new ModelAndView("delivery-info");
         modelAndView.addObject(orderService.retrieveDeliveryInfo(trackingNo));
+
         return modelAndView;
     }
 

--- a/src/main/java/com/nhnacademy/marketgg/client/web/order/OrderPageController.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/web/order/OrderPageController.java
@@ -3,6 +3,7 @@ package com.nhnacademy.marketgg.client.web.order;
 import com.nhnacademy.marketgg.client.dto.MemberInfo;
 import com.nhnacademy.marketgg.client.dto.PageResult;
 import com.nhnacademy.marketgg.client.dto.order.OrderDetailRetrieveResponse;
+import com.nhnacademy.marketgg.client.dto.order.OrderFormResponse;
 import com.nhnacademy.marketgg.client.dto.order.OrderRetrieveResponse;
 import com.nhnacademy.marketgg.client.dto.request.CartOrderRequest;
 import com.nhnacademy.marketgg.client.paging.Pagination;
@@ -12,15 +13,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
  * 주문과 관련된 페이지 요청 처리를 담당합니다.
  *
- * @author 이제훈, 김정민
+ * @author 김정민
+ * @author 이제훈
  * @version 1.0
  * @since 1.0
  */
@@ -36,10 +38,13 @@ public class OrderPageController {
      *
      * @return 주문서 작성 페이지
      */
-    @GetMapping("/orders/form")
-    public ModelAndView goOrderForm(@ModelAttribute CartOrderRequest cartOrderReqeust, final MemberInfo memberInfo) {
+    @PostMapping("/orders/form")
+    public ModelAndView goOrderForm(CartOrderRequest cartRequest, final MemberInfo memberInfo) {
+        OrderFormResponse orderFormResponse = orderService.retrieveOrderForm(cartRequest);
+
         ModelAndView mav = new ModelAndView("pages/orders/order-form");
-        mav.addObject(memberInfo);
+        mav.addObject("member", memberInfo);
+        mav.addObject("result", orderFormResponse);
 
         return mav;
     }

--- a/src/main/java/com/nhnacademy/marketgg/client/web/payment/PaymentPageController.java
+++ b/src/main/java/com/nhnacademy/marketgg/client/web/payment/PaymentPageController.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.marketgg.client.web.payment;
 
+import com.nhnacademy.marketgg.client.dto.order.OrderToPayment;
 import com.nhnacademy.marketgg.client.service.payment.PaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -23,8 +24,11 @@ public class PaymentPageController {
     private final PaymentService paymentService;
 
     @GetMapping("/request-payment")
-    public ModelAndView index() {
-        return new ModelAndView("pages/payments/request-payment");
+    public ModelAndView index(OrderToPayment orderToPayment) {
+        ModelAndView mav = new ModelAndView("pages/payments/request-payment");
+        mav.addObject("result", orderToPayment);
+
+        return mav;
     }
 
     @GetMapping("/success-payment")

--- a/src/main/resources/static/css/orders/order-form.css
+++ b/src/main/resources/static/css/orders/order-form.css
@@ -1,6 +1,5 @@
 main {
     display: flex;
-    border: 1px solid #000;
     flex-direction: column;
     justify-content: center;
     align-items: center;
@@ -13,27 +12,31 @@ p {
     margin: 0;
 }
 
+form {
+    width: 70%;
+}
+
+h1 {
+    text-align: center;
+}
+
 section {
     padding: 3rem;
-    width: inherit;
-    /* border: 1px solid crimson; */
 }
 
 .order-products div {
-    /* border: 1px solid #000; */
     margin: 1rem 1rem 1rem 0;
 }
 
 ul {
-    border: 1px solid #000;
     padding: 0;
     margin: 0;
+    list-style-type: none;
 }
 
 .order-products li {
     display: flex;
 }
-
 
 .customer-information div {
     display: flex;
@@ -53,6 +56,11 @@ ul {
 .customer-information p:last-child {
     display: flex;
     flex: 0.7;
+}
+
+.delivery-information ul, .benefits ul {
+    display: flex;
+    justify-content: space-between;
 }
 
 .benefits div {

--- a/src/main/resources/static/plugins/autocomplete/css/autoComplete.02.css
+++ b/src/main/resources/static/plugins/autocomplete/css/autoComplete.02.css
@@ -4,7 +4,7 @@
 }
 
 .autoComplete_wrapper > input {
-  /* width: 370px; */
+  width: 16rem;
   height: 40px;
   padding-left: 10px;
   font-size: 1rem;

--- a/src/main/resources/static/plugins/clickymenus/css/clicky-menus.css
+++ b/src/main/resources/static/plugins/clickymenus/css/clicky-menus.css
@@ -24,6 +24,14 @@ svg[hidden] {
     align-items: center;
 }
 
+/* .subcategory { */
+/*     display: none; */
+/* } */
+
+/* .subcategory:hover { */
+/*     display: block; */
+/* } */
+
 @media (min-width: 540px) {
     .clicky-menu {
         display: flex;

--- a/src/main/resources/static/plugins/marketgg/css/marketgg.common.css
+++ b/src/main/resources/static/plugins/marketgg/css/marketgg.common.css
@@ -28,21 +28,29 @@
 
 nav {
     display: flex;
-    justify-content: space-around;
+    justify-content: center;
     flex: 1;
     box-shadow: 2px 4px 4px rgb(0 0 0 / 20%);
+}
+
+.custom-select {
+    width: 9rem;
 }
 
 .autocomplete-input {
     display: flex;
 }
 
+.autocomplete-container {
+    margin-left: 3rem;
+}
+
 .autocomplete-container div:last-child {
     margin-left: 0.5rem;
 }
 
-.fa-search {
-    color: white;
+.fa-search-dollar {
+    color: ghostwhite;
     cursor: pointer;
     font-size: 2rem;
 }
@@ -101,4 +109,28 @@ footer a {
 
 footer a:hover {
     color: lightskyblue;
+}
+
+.user-info {
+    display: flex;
+    align-items: center;
+}
+
+.fa-shopping-cart {
+    color: white;
+    font-size: 1.5rem;
+}
+
+.authentication-name {
+    margin: 0 1.5rem 0 1rem;
+}
+
+@media (max-width: 576px) {
+    nav, .clicky-menu {
+        flex-direction: column;
+    }
+
+    .autocomplete-container {
+        justify-content: flex-end;
+    }
 }

--- a/src/main/resources/static/plugins/tosspayments/js/payment.js
+++ b/src/main/resources/static/plugins/tosspayments/js/payment.js
@@ -1,17 +1,17 @@
+// SEE: https://developers.tosspayments.com/304121/accounts/411128/phases/test/payment-logs
 window.addEventListener('DOMContentLoaded', () => {
   const clientKey = 'test_ck_k6bJXmgo28e1RagkzMe8LAnGKWx4';
+  const clientOrigin = 'http://localhost:5050';
   const tossPayments = TossPayments(clientKey);
 
-  const randomValue = Math.floor(Math.random() * 100_001);
-
-  tossPayments.requestPayment('가상계좌', {
-    amount: 1000,
-    orderId: 'GGORDER_' + randomValue,
-    orderName: '[생어거스틴] 새우 듬뿍 팟타이 밀키트 외 3건',
-    successUrl: 'http://127.0.0.1:5050/payments/success',
-    failUrl: 'http://127.0.0.1:5050/payments/fail',
+  tossPayments.requestPayment('카드', {
+    amount: document.getElementById('amount').textContent,
+    orderId: document.getElementById('orderId').textContent,
+    orderName: document.getElementById('orderName').textContent,
+    successUrl: `${clientOrigin}/payments/success`,
+    failUrl: `${clientOrigin}/payments/fail`,
     windowTarget: "iframe",
-    customerName: '강태풍',
-    customerEmail: 'on7.marketgg@gmail.com',
+    customerName: document.getElementById('customerName').textContent,
+    customerEmail: document.getElementById('customerEmail').textContent,
   });
 });

--- a/src/main/resources/templates/fragments/common/gnb.html
+++ b/src/main/resources/templates/fragments/common/gnb.html
@@ -10,7 +10,16 @@
                 </a>
                 <ul class="category">
                     <!-- FIXME: DB 에서 상위 카테고리 each 돌리기 -->
-                    <li><a th:href="@{/products/categories/104}" th:text="밀키트"></a></li>
+                    <li>
+                        <a th:href="@{/products/categories/104}" th:text="밀키트"></a>
+                        <ul class="subcategory">
+                            <!-- FIXME: DB 에서 상위 카테고리 each 돌리기 -->
+                            <li th:text="밀키트2"></a></li>
+                            <li th:text="채소2"></a></li>
+                            <li th:text="|과일/견과/쌀2|"></a></li>
+                            <li th:text="|정육/계란2|"></a></li>
+                        </ul>
+                    </li>
                     <li><a th:href="@{/products/categories/101}" th:text="채소"></a></li>
                     <li><a th:href="@{/products/categories/102}" th:text="|과일/견과/쌀|"></a></li>
                     <li><a th:href="@{/products/categories/103}" th:text="|정육/계란|"></a></li>
@@ -22,20 +31,22 @@
     </div>
     <div class="autocomplete-container">
         <label for="categoryCode"></label>
-        <select class="form-select-sm" aria-label="Default select example" id="categoryCode">
-            <option selected th:text="'전체'" th:value="'001'"></option>
-            <option th:text="'채소'" th:value="'101'"></option>
-            <option th:text="'과일/견과/쌀'" th:value="'102'"></option>
-            <option th:text="'정육/계란'" th:value="'103'"></option>
-            <option th:text="'밀키트'" th:value="'104'"></option>
-        </select>
+        <div class="dropdown">
+            <select class="custom-select" id="categoryCode">
+                <option selected th:text="'전체'" th:value="'001'"></option>
+                <option th:text="'채소'" th:value="'101'"></option>
+                <option th:text="'과일/견과/쌀'" th:value="'102'"></option>
+                <option th:text="'정육/계란'" th:value="'103'"></option>
+                <option th:text="'밀키트'" th:value="'104'"></option>
+            </select>
+        </div>
         <div class="autocomplete-input">
             <label for="autoComplete"></label>
             <input id="autoComplete" type="search" dir="ltr" maxlength="2048" tabindex="1"
                    spellcheck=false autocorrect="off" autocomplete="off" autocapitalize="off">
         </div>
         <div>
-            <i class="fas fa-search"></i>
+            <i class="fas fa-search-dollar"></i>
         </div>
     </div>
 </nav>

--- a/src/main/resources/templates/fragments/common/header.html
+++ b/src/main/resources/templates/fragments/common/header.html
@@ -1,34 +1,34 @@
-<header>
-    <div class="navbar navbar-dark bg-dark shadow-sm">
-        <div class="container d-flex justify-content-between">
-            <a href="/" class="navbar-brand d-flex align-items-center">
-                <i class="fab fa-shopify"></i>
-                <strong>Market GG</strong>
-            </a>
-            <div style="display: flex">
-                <div class="dropdown">
-                    <button class="btn" type="button" data-toggle="dropdown" aria-expanded="false">
-                        <i class="fas fa-globe" style="font-size: 1.5rem; line-height: 1.7; color: white;"></i>
-                    </button>
-                    <div class="dropdown-menu">
-                        <a class="dropdown-item" th:href="@{__${#httpServletRequest.requestURI}__?lang=ko}"
-                           th:text="#{KOREAN}"></a>
-                        <a class="dropdown-item" th:href="@{__${#httpServletRequest.requestURI}__?lang=en}"
-                           th:text="#{ENGLISH}"></a>
+<html lang="ko" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+    <header>
+        <div class="navbar navbar-dark bg-dark shadow-sm">
+            <div class="container d-flex justify-content-between">
+                <a href="/" class="navbar-brand d-flex align-items-center">
+                    <i class="fab fa-shopify"></i>
+                    <strong>Market GG</strong>
+                </a>
+                <div style="display: flex">
+                    <div class="dropdown">
+                        <button class="btn" type="button" data-toggle="dropdown" aria-expanded="false">
+                            <i class="fas fa-globe" style="font-size: 1.5rem; line-height: 1.7; color: white;"></i>
+                        </button>
+                        <div class="dropdown-menu">
+                            <a class="dropdown-item" th:href="@{__${#httpServletRequest.requestURI}__?lang=ko}"
+                               th:text="#{KOREAN}"></a>
+                            <a class="dropdown-item" th:href="@{__${#httpServletRequest.requestURI}__?lang=en}"
+                               th:text="#{ENGLISH}"></a>
+                        </div>
                     </div>
-                </div>
-                <div sec:authorize="isAnonymous()">
-                    <a href="/signup" class="btn btn-primary my-2" th:text="#{SIGN_UP}"></a>
-                    <a href="/login" class="btn btn-secondary my-2" th:text="#{LOGIN}"></a>
-                </div>
-                <div sec:authorize="!isAnonymous()">
-                    <span th:text="|Hello, ${#authentication.name}!|"></span>
-                    <a href="/cart">
-                        <i class="bi-cart-fill me-1"></i>
-                    </a>
-                    <a href="/logout" class="btn btn-secondary my-2" th:text="#{LOGOUT}"></a>
+                    <div sec:authorize="isAnonymous()">
+                        <a href="/signup" class="btn btn-primary my-2" th:text="#{SIGN_UP}"></a>
+                        <a href="/login" class="btn btn-secondary my-2" th:text="#{LOGIN}"></a>
+                    </div>
+                    <div sec:authorize="!isAnonymous()" class="user-info">
+                        <a href="/cart"><i class="fas fa-shopping-cart"></i></a>
+                        <span class="authentication-name" th:text="|Hello, ${#authentication.name}!|"></span>
+                        <a href="/logout" class="btn btn-secondary my-2" th:text="#{LOGOUT}"></a>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-</header>
+    </header>
+</html>

--- a/src/main/resources/templates/pages/members/login.html
+++ b/src/main/resources/templates/pages/members/login.html
@@ -5,7 +5,7 @@
     <head>
         <meta charset="UTF-8">
         <title>Market GG</title>
-        <link th:href="@{css/members/login.css}" rel="stylesheet">
+        <link th:href="@{/css/members/login.css}" rel="stylesheet">
         <script></script>
     </head>
     <body>

--- a/src/main/resources/templates/pages/orders/order-form.html
+++ b/src/main/resources/templates/pages/orders/order-form.html
@@ -20,17 +20,14 @@
                     <h2>주문 상품</h2>
                     <hr>
                     <ul>
-                        <li>
+                        <li th:each="product : ${result.products}">
                             <div style="width: 100px; height: 100px; background: url('https://img-cf.kurly.com/shop/data/goods/1653037091448l0.jpeg')"></div>
-                            <div><a href="#"><p>[Kim's Butcher] 미국산 우삼겹 돌돌말이 500g (냉동)</p></a></div>
-                        </li>
-                        <li>
-                            <div style="width: 100px; height: 100px; background: url('https://img-cf.kurly.com/shop/data/goods/1653037091448l0.jpeg')"></div>
-                            <div><a href="#"><p>[자이글] 캠핑그리들 30cm</p></a></div>
-                        </li>
-                        <li>
-                            <div style="width: 100px; height: 100px; background: url('https://img-cf.kurly.com/shop/data/goods/1653037091448l0.jpeg')"></div>
-                            <div><a href="#"><p>[닥터지] 로얄 블랙 스네일 크림 50ml</p></a></div>
+                            <div>
+                                <a href="#"><p th:text="${product.name}"></p></a>
+                                <a href="#"><p th:text="${product.price}"></p></a>
+                                <a href="#"><p th:text="${product.amount}"></p></a>
+                            </div>
+                            <input type="hidden" name="productIds" th:value="${product.id}">
                         </li>
                     </ul>
                 </section>
@@ -40,34 +37,48 @@
                     <hr>
                     <div>
                         <p>보내는 분</p>
-                        <p>강태풍</p>
+                        <p th:text="${result.memberName}"></p>
+                        <input type="hidden" name="name" th:value="${result.memberName}">
                     </div>
                     <div>
                         <p>휴대폰</p>
                         <p>010-8765-4321</p>
                     </div>
                     <div>
-                        <p>이메일</p>
-                        <p>on7.marketgg@gmail.com</p>
+                        <p th:text="#{EMAIL_LABEL}"></p>
+                        <p th:text="${result.memberEmail}"></p>
+                        <input type="hidden" name="email" th:value="${result.memberEmail}">
                     </div>
                 </section>
 
                 <section class="delivery-information">
                     <h2>배송지</h2>
                     <hr>
-                    <p>상세 정보</p>
+                    <ul th:each="deliveryAddress: ${result.deliveryAddressList}">
+                       <li th:text="${deliveryAddress.isDefaultAddress}"></li>
+                       <li th:text="${deliveryAddress.zipcode}"></li>
+                       <li th:text="${deliveryAddress.address}"></li>
+                       <li th:text="${deliveryAddress.detailAddress}"></li>
+                    </ul>
+                    <input type="hidden" name="deliveryAddressId" th:value="${result.deliveryAddressList[0].id}">
                 </section>
 
                 <section class="benefits">
                     <h2>쿠폰 / 적립금</h2>
                     <hr>
-                    <div>
+                    <div style="flex-direction: column;">
                         <p>쿠폰 적용</p>
-                        <input type="text">
+                        <ul th:each="givenCoupon: ${result.givenCouponList}">
+                            <li th:text="${givenCoupon.name}"></li>
+                            <li th:text="${givenCoupon.createdAt}"></li>
+                            <li th:text="${givenCoupon.expiredDate}"></li>
+                            <li th:text="${givenCoupon.minimumMoney}"></li>
+                            <li th:text="${givenCoupon.discountAmount}"></li>
+                        </ul>
                     </div>
                     <div>
                         <p>적립금 적용</p>
-                        <input type="number">
+                        <input type="number" name="usedPoint" th:value="${result.totalPoint}">
                     </div>
                 </section>
 
@@ -93,14 +104,10 @@
                 </aside> -->
 
                 <!-- FIXME: 유효성 검사 반영되어 있음. 필요한 값 수정 필요 -->
-                <input type="hidden" name="totalAmount" value="6750" />
-                <input type="hidden" name="usedPoint" value="0" />
-                <!-- <input type="hidden" name="orderId" value="58209b22-e25a-47b4-9434-020c0f46c5c6" /> -->
-                <input type="hidden" name="orderName" value="[Kim's Butcher] 미국산 우삼겹 돌돌말이 500g (냉동) 외 2건" />
-                <input type="hidden" name="customerName" value="강태풍" />
-                <input type="hidden" name="customerEmail" value="on7.marketgg@gmail.com" />
+                <input type="hidden" name="totalAmount" th:value="${result.totalOrigin}" />
+                <input type="hidden" name="expectedSavePoint" th:value="${result.totalOrigin}" />
 
-                <button type="submit" id="payment-button" class="btn btn-primary my-2">6,750원 결제하기</button>
+                <button id="payment-button" class="btn btn-primary my-2" th:text="결제하기"></button>
             </form>
         </main>
     </body>

--- a/src/main/resources/templates/pages/payments/request-payment.html
+++ b/src/main/resources/templates/pages/payments/request-payment.html
@@ -13,6 +13,11 @@
     <body>
         <main>
             <h1>결제 요청이 진행중입니다.</h1>
+            <p id="orderId" th:text="${result.orderId}"></p>
+            <p id="orderName" th:text="${result.orderName}"></p>
+            <p id="customerName" th:text="${result.memberName}"></p>
+            <p id="customerEmail" th:text="${result.memberEmail}"></p>
+            <p id="amount" th:text="${result.totalAmount}"></p>
         </main>
     </body>
 


### PR DESCRIPTION
## 개요

- Closes #228 
- 주문 프로세스(장바구니 - 주문 - 결제 연동) 구현

## 작업 사항

- [x] 사용하지 않는 `import` 제거 (`CartController`)
- [x] 장바구니 - 주문 - 결제 프로세스에 맞도록 DTO 수정 (+ *validation* 추가, @bunsung92)
- [x] 주문서 작성 프로세스에 맞도록 레이어별 수정 ⭐ (@Jungmin-Kim228)
- [x] 결제 요청 컨트롤러 응답 데이터 반영
- [x] 공통 레이아웃에 적용되는 각종 CSS 수정
